### PR TITLE
Streaming.Zip: fix Ambiguous occurrence ‘for’

### DIFF
--- a/Streaming/Zip.hs
+++ b/Streaming/Zip.hs
@@ -28,7 +28,7 @@ import           Data.Streaming.Zlib       as Z
 import           Control.Exception         (throwIO)
 import           Control.Monad             (unless)
 import qualified Data.ByteString           as B
-import Data.ByteString.Streaming 
+import Data.ByteString.Streaming hiding (for)
 import Streaming
 import qualified Data.ByteString.Streaming.Internal as I 
 import Data.ByteString.Streaming.Internal (ByteString (..)) 


### PR DESCRIPTION
This fixes:

```
Streaming/Zip.hs:53:10: error:
Error:     Ambiguous occurrence ‘for’
    It could refer to either ‘Data.ByteString.Streaming.for’,
                             imported from ‘Data.ByteString.Streaming’ at Streaming/Zip.hs:31:1-32
                             (and originally defined in ‘Streaming.ByteString’)
                          or ‘Streaming.Zip.for’, defined at Streaming/Zip.hs:192:1
   |
53 |     r <- for p0 $ \bs -> do
   |          ^^^
```

Found in hid-examples CI:
https://github.com/bravit/hid-examples/runs/8125768251
https://app.travis-ci.com/github/bravit/hid-examples/jobs/581514513